### PR TITLE
Use correct API compatibility for OpenSSL dependency

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -118,6 +118,11 @@ class LibcurlConan(ConanFile):
 
         self.requires.add("zlib/1.2.11@conan/stable")
 
+    def package_id(self):
+        if "OpenSSL" in self.info.requires.pkg_names:
+            openssl = self.info.requires["OpenSSL"]
+            openssl.version = openssl.full_version.minor()
+
     def source(self):
         tools.get("https://curl.haxx.se/download/curl-%s.tar.gz" % self.version)
         os.rename("curl-%s" % self.version, self.source_subfolder)


### PR DESCRIPTION
This fixes problem when OpenSSL dependency is overridden to version 1.1.

For example
```
D:> type ..\conanfile.txt
[requires]
libcurl/7.60.0@bincrafters/stable
# overrides
OpenSSL/1.1.0g@conan/stable
[generators]
cmake

D:> conan install ..
D:> cmake \projects\conan-libcurl\test_package\
D:> cmake --build .
```
will result in errors
```
  libcurl.lib(openssl.obj) : error LNK2019: unresolved external symbol _sk_num referenced in function _X509V3_ext [D:\tmp\conan-libcurl-test\build_test\test_package.vcxproj]
  libcurl.lib(openssl.obj) : error LNK2019: unresolved external symbol _sk_value referenced in function _X509V3_ext [D:\tmp\conan-libcurl-test\build_test\test_package.vcxproj]
...
  D:\tmp\conan-libcurl-test\build_test\bin\test_package.exe : fatal error LNK1120: 16 unresolved externals [D:\tmp\conan-libcurl-test\build_test\test_package.vcxproj]
```
because libcurl binary package from remote is used and that package was build with OpenSSL 1.0.2n