### PR TITLE
OpenSSL dependency 1.0.2n -> 1.1.0g - fix multi-threading

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -120,7 +120,7 @@ class LibcurlConan(ConanFile):
             elif self.settings.os == "Windows" and self.options.with_winssl:
                 pass
             else:
-                self.requires.add("OpenSSL/1.0.2n@conan/stable")
+                self.requires.add("OpenSSL/1.1.0g@conan/stable")
         if self.options.with_libssh2:
             if self.settings.compiler != "Visual Studio":
                 self.requires.add("libssh2/1.8.0@bincrafters/stable")


### PR DESCRIPTION
I have a toy [application](https://github.com/nigels-com/slippymap3d) that uses lots of threads with libcurl to fetch image tiles over HTTP/HTTPS.

It seems to work fine for Ubuntu 18.04 libcurl, but not for `libcurl/7.61.1@bincrafters/stable`.

When I bumped the OpenSSL from 1.0.2n to 1.1.0g, it seems to resolve the problem (no crashing!).

I appreciate that you might choose not to merge this to 7.61.1 branch specifically, but FYI...

![screenshot from 2018-10-14 22-38-32](https://user-images.githubusercontent.com/545677/46916744-ff34df80-d001-11e8-9861-61e8da31486b.png)
