### PR TITLE
Mingw cross

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,21 +12,51 @@ environment:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 12
           CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86_64
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 12
           CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86_64
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
           CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86_64
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
           CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86_64
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86_64
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86_64
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+          CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86
 
 install:
   - set PATH=%PATH%;%PYTHON%/Scripts/

--- a/conanfile.py
+++ b/conanfile.py
@@ -110,6 +110,9 @@ class LibcurlConan(ConanFile):
                 pass
             elif self.settings.os == "Windows" and self.options.with_winssl:
                 pass
+            elif self.settings.os == "Windows" and tools.cross_building(self.settings):
+                # only recent OpenSSL packages allow cross-building
+                self.requires.add("OpenSSL/1.1.1a@conan/stable")
             else:
                 self.requires.add("OpenSSL/1.0.2n@conan/stable")
         if self.options.with_libssh2:

--- a/conanfile.py
+++ b/conanfile.py
@@ -322,7 +322,8 @@ class LibcurlConan(ConanFile):
                 tools.save(os.path.join('lib', 'Makefile.am'), added_content, append=True)
 
     def build_with_autotools(self):
-        autotools = AutoToolsBuildEnvironment(self, win_bash=self.is_mingw)
+        use_win_bash = self.is_mingw and not tools.cross_building(self.settings)
+        autotools = AutoToolsBuildEnvironment(self, win_bash=use_win_bash)
 
         if self.settings.os != "Windows":
             autotools.fpic = self.options.fPIC
@@ -351,7 +352,7 @@ class LibcurlConan(ConanFile):
         with tools.environment_append(env_run.vars):
             with tools.chdir(self.source_subfolder):
                 # autoreconf
-                self.run('./buildconf', win_bash=self.is_mingw)
+                self.run('./buildconf', win_bash=use_win_bash)
 
                 # fix generated autotools files
                 tools.replace_in_file("configure", "-install_name \\$rpath/", "-install_name ")

--- a/conanfile.py
+++ b/conanfile.py
@@ -302,9 +302,11 @@ class LibcurlConan(ConanFile):
                                   '')
 
             # patch for zlib naming in mingw
-            tools.replace_in_file("configure.ac",
-                                  '-lz ',
-                                  '-lzlib ')
+            # when cross-building, the name is correct
+            if not tools.cross_building(self.settings):
+                tools.replace_in_file("configure.ac",
+                                      '-lz ',
+                                      '-lzlib ')
 
             if self.options.shared:
                 # patch for shared mingw build
@@ -318,8 +320,10 @@ class LibcurlConan(ConanFile):
                                       'lib_LTLIBRARIES = libcurl.la',
                                       'noinst_LTLIBRARIES = libcurl.la')
                 # add directives to build dll
-                added_content = tools.load(os.path.join(self.source_folder, 'lib_Makefile_add.am'))
-                tools.save(os.path.join('lib', 'Makefile.am'), added_content, append=True)
+                # used only for native mingw-make
+                if not tools.cross_building(self.settings):
+                    added_content = tools.load(os.path.join(self.source_folder, 'lib_Makefile_add.am'))
+                    tools.save(os.path.join('lib', 'Makefile.am'), added_content, append=True)
 
     def build_with_autotools(self):
         use_win_bash = self.is_mingw and not tools.cross_building(self.settings)

--- a/conanfile.py
+++ b/conanfile.py
@@ -161,6 +161,8 @@ class LibcurlConan(ConanFile):
     def package_info(self):
         if self.settings.compiler != "Visual Studio":
             self.cpp_info.libs = ['curl']
+            if self.settings.compiler in ("clang", "gcc"):
+                self.cpp_info.libs += ["pthread"]
             if self.settings.os == "Linux":
                 self.cpp_info.libs.extend(["rt", "pthread"])
                 if self.options.with_libssh2:

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -17,17 +17,18 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        with tools.environment_append(RunEnvironment(self).vars):
+        if "arm" in self.settings.arch:
+            self.test_arm()
+        elif tools.cross_building(self.settings) and self.settings.os == "Windows":
+            self.test_mingw_cross()
+        else:
             bin_path = os.path.join("bin", "test_package")
-            if self.settings.os == "Windows":
-                self.run(bin_path)
-            elif self.settings.os == "Macos":
-                self.run("DYLD_LIBRARY_PATH=%s %s" % (os.environ.get('DYLD_LIBRARY_PATH', ''), bin_path))
-            else:
-                if "arm" in self.settings.arch:
-                    self.test_arm()
-                else:
-                    self.run("LD_LIBRARY_PATH=%s %s" % (os.environ.get('LD_LIBRARY_PATH', ''), bin_path))
+            self.run(bin_path, run_environment=True)
+
+    def test_mingw_cross(self):
+        bin_path = os.path.join("bin", "test_package.exe")
+        output = subprocess.check_output(["file", bin_path]).decode()
+        assert re.search(r"PE32.*executable.*Windows", output)
 
     def test_arm(self):
         file_ext = "so" if self.options["libcurl"].shared else "a"


### PR DESCRIPTION
Introduce support for cross-compiling for mingw.
Should fix bincrafters/community#626

Steps to reproduce:
- add an example profile mingw
- `apt-get install g++-mingw-w64` on debian stable
- `conan create . --build=missing --build=libcurl bincrafters/testing --profile mingw`

A cross mingw build differs from the native mingw build with patching of several files and should work better than a native mingw build.