### PR TITLE
Add cross-build Linux-to-Windows to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
       - <<: *linux
         env: CONAN_GCC_VERSIONS=7 CONAN_ARCHS=armv7 CONAN_DOCKER_IMAGE=lasote/conangcc7-armv7 CONAN_BUILD_TYPES=Release CONAN_BUILD_POLICY=missing
       - <<: *linux
+        env: CONAN_GCC_VERSIONS=7 CONAN_ARCHS=x86_64 CONAN_DOCKER_IMAGE=bincrafters/docker-mingw-gcc7 CONAN_BUILD_TYPES=Release CONAN_BUILD_POLICY=missing _CONAN_TARGET_OS=Windows
+      - <<: *linux
         env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=conanio/gcc49
       - <<: *linux
         env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=conanio/gcc5

--- a/build.py
+++ b/build.py
@@ -5,6 +5,7 @@
 from bincrafters import build_template_default
 import platform
 import copy
+import os
 
 if __name__ == "__main__":
 
@@ -31,5 +32,20 @@ if __name__ == "__main__":
                 items.append([item.settings, new_options, item.env_vars,
                               new_build_requires, item.reference])
     builder.items = items
+
+    if os.getenv("_CONAN_TARGET_OS", None):
+        # Add non-shared builds with specific target OS
+        items = []
+        for item in builder.items:
+            if item.options["libcurl:shared"] == False:
+                new_settings = copy.copy(item.settings)
+                new_settings["os"] = os.getenv("_CONAN_TARGET_OS")
+                new_options = copy.copy(item.options)
+                new_options["libcurl:with_openssl"] = False
+
+                items.append([new_settings, new_options, item.env_vars,
+                    item.build_requires, item.reference])
+
+        builder.items = items
 
     builder.run()


### PR DESCRIPTION
Experimental build is motivated by #16 – it is useful to automatically check linux-to-windows cross-build

Build is performed on `bincrafters/docker-mingw-gcc7` docker image which was recently updated to have autotools.

 zlib cross-builds fine now. OpenSSL dependency is temporarily turned off but should work.

Build configuration with settings.os=Windows is generated by the `build.py` when the env variable `_CONAN_TARGET_OS` is set (it is set in travis job).