### PR TITLE
test_arm: recognize armv8/armv8_32 machine outputs

### DIFF
--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -34,4 +34,11 @@ class TestPackageConan(ConanFile):
         file_ext = "so" if self.options["libcurl"].shared else "a"
         lib_path = os.path.join(self.deps_cpp_info["libcurl"].libdirs[0], "libcurl.%s" % file_ext)
         output = subprocess.check_output(["readelf", "-h", lib_path]).decode()
-        assert re.search(r"Machine:\s+ARM", output)
+
+        if "armv8" in self.settings.arch:
+            if self.settings.arch == "armv8_32":
+                assert re.search(r"Machine:\s+ARM", output)
+            else:
+                assert re.search(r"Machine:\s+AArch64", output)
+        else:
+            assert re.search(r"Machine:\s+ARM", output)


### PR DESCRIPTION
readelf -h on AArch64 binaries will show the machine as `AArch64`; this PR updates the `test_arm` method to expect that when building for `armv8`.

(I don't have an `armv8_32` machine around to test the `armv8_32` case, but it seems like it should report `ARM`.  Feel free to remove that case, though, if you don't want untested branches in the test package.)