### PR TITLE
Handle build_type=Debug

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -168,6 +168,9 @@ class LibcurlConan(ConanFile):
         params.append("--without-libpsl" if not self.options.with_libpsl else "--with-libpsl")
         params.append("--without-brotli" if not self.options.with_brotli else "--with-brotli")
 
+        if self.settings.build_type == 'Debug':
+            params.append("--enable-debug")
+
         if not self.options.get_safe("with_largefile"):
             params.append("--disable-largefile")
 


### PR DESCRIPTION
I'm not getting debug symbols in my libcurl package with `build_type=Debug`

This patch adds the `--enable-debug` flag which sets the debug options (`-g` for gcc).
I tested this modification on the 7.66.0 stable package and I am now seeing debug symbols according to `objdump --debugging libcurl.a` on my locally built package.